### PR TITLE
Check for valid ISO 4217 currency code

### DIFF
--- a/src/Vendr.Contrib.PaymentProviders.Square/SquareCheckoutOnetimePaymentProvider.cs
+++ b/src/Vendr.Contrib.PaymentProviders.Square/SquareCheckoutOnetimePaymentProvider.cs
@@ -78,6 +78,12 @@ namespace Vendr.Contrib.PaymentProviders.Square
             var currency = Vendr.Services.CurrencyService.GetCurrency(order.CurrencyId);
             var currencyCode = currency.Code.ToUpperInvariant();
 
+            // Ensure currency has valid ISO 4217 code
+            if (!Iso4217.CurrencyCodes.ContainsKey(currencyCode))
+            {
+                throw new Exception("Currency must be a valid ISO 4217 currency code: " + currency.Name);
+            }
+
             var accessToken = settings.SandboxMode ? settings.SandboxAccessToken : settings.LiveAccessToken;
             var environment = settings.SandboxMode ? SquareSdk.Environment.Sandbox : SquareSdk.Environment.Production;
 


### PR DESCRIPTION
Square also requires a standard ISO 4217 currency code https://developer.squareup.com/docs/build-basics/working-with-monetary-amounts so it would be great to do a check for a valid ISO 4217 currency code like we do in most other payment providers.