### PR TITLE
Use AmountToMinorUnits base method

### DIFF
--- a/src/Vendr.Contrib.PaymentProviders.Square/SquareCheckoutOnetimePaymentProvider.cs
+++ b/src/Vendr.Contrib.PaymentProviders.Square/SquareCheckoutOnetimePaymentProvider.cs
@@ -92,15 +92,14 @@ namespace Vendr.Contrib.PaymentProviders.Square
                 .Name("Vendr")
                 .Build();
 
-            var totalPrice = Convert.ToInt64(order.TotalPrice.Value.WithoutTax * 100);
-            var totalTax = Convert.ToInt64(order.TotalPrice.Value.Tax * 100);
+            var orderAmount = AmountToMinorUnits(order.TotalPrice.Value.WithoutTax);
 
             var bodyOrderOrderLineItems = new List<OrderLineItem>()
             {
                 new OrderLineItem("1",
                     order.Id.ToString(),
                     order.OrderNumber,
-                    basePriceMoney: new Money(totalPrice, currencyCode))
+                    basePriceMoney: new Money(orderAmount, currencyCode))
             };
 
             var orderReference = order.GenerateOrderReference();


### PR DESCRIPTION
Since Vendr now has basae method `AmountToMinorUnits()` it would be great to use this here.
I have also used `totalTax` for now since it wasn't used.
